### PR TITLE
Added propper HTML5 DocType

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>Geoweb</title>


### PR DESCRIPTION
It's not a big deal, but when using HTML5 tags like `canvas` it's good custom to set propper HTML `Doctype` to make sure browsers know what it is they are going to be working with.